### PR TITLE
update import order

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
-from termcolor import colored
 import csv
+
+from termcolor import colored
 
 import lesson
 


### PR DESCRIPTION
pylintで構文チェックした際に出てきた以下の警告を回避

> main.py:2:0: C0411: standard import "csv" should be placed before third party import "termcolor.colored" (wrong-import-order)main.py:2:0: C0411: standard import "csv" should be placed before third party import "termcolor.colored" (wrong-import-order)
